### PR TITLE
Reimplement `Instant` to measure time across suspend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ### next
+- use a custom implementation of `Instant`
 - begin properly handling times of 0 as empty
 - add system font finding
 - add two-line splits

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "mist"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "mist-core",
  "sdl2",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "mist-core"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "libc",
  "ron",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,9 +251,8 @@ dependencies = [
 [[package]]
 name = "mist-core"
 version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccd15281f90d3fe9ae2db0097d6278844ef8cd4273039b72c3df3c96ae59426"
 dependencies = [
+ "libc",
  "ron",
  "rust-fontconfig",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ features = ["ttf"]
 
 [dependencies.mist-core]
 version = "0.8"
+path = "./crates/mist-core/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mist"
-version = "1.13.2"
+version = "1.14.0"
 authors = ["LtPeriwinkle <not.yet.periwinkle@gmail.com>"]
 include = ["assets/", "assets/*", "src/*.rs"]
 edition = "2018"
@@ -23,5 +23,5 @@ default-features = false
 features = ["ttf"]
 
 [dependencies.mist-core]
-version = "0.8"
+version = "0.9"
 path = "./crates/mist-core/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["bg", "icon"]
+default = ["bg", "icon", "instant"]
+instant = ["mist-core/instant"]
 bg = ["sdl2/gfx", "sdl2/image", "mist-core/bg"]
 icon = ["sdl2/image"]
 

--- a/crates/mist-core/CHANGELOG.md
+++ b/crates/mist-core/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## mist-core changelog
+### 0.9.0
+- implement a custom `Instant` to measure time across system suspends
+
 ### 0.8.2
 - check for general run sanity before returning a parsed run or writing a run to msf
 

--- a/crates/mist-core/Cargo.toml
+++ b/crates/mist-core/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0 OR MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["timing", "dialogs", "config", "instant"]
+default = ["timing", "dialogs", "config"]
 lss = ["quick-xml"]
 timing = []
 dialogs = ["tinyfiledialogs"]

--- a/crates/mist-core/Cargo.toml
+++ b/crates/mist-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mist-core"
-version = "0.8.2"
+version = "0.9.0"
 authors = ["LtPeriwinkle <not.yet.periwinkle@gmail.com>"]
 edition = "2018"
 description = "core functionality of mist"

--- a/crates/mist-core/Cargo.toml
+++ b/crates/mist-core/Cargo.toml
@@ -11,12 +11,13 @@ license = "Apache-2.0 OR MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["timing", "dialogs", "config"]
+default = ["timing", "dialogs", "config", "instant"]
 lss = ["quick-xml"]
 timing = []
 dialogs = ["tinyfiledialogs"]
 config = ["rust-fontconfig"]
 bg = ["config"]
+instant = ["libc"]
 
 [dependencies.ron]
 version = "0.6"
@@ -36,4 +37,8 @@ optional = true
 
 [dependencies.rust-fontconfig]
 version = "0.1.5"
+optional = true
+
+[dependencies.libc]
+version = "0.2"
 optional = true

--- a/crates/mist-core/README.md
+++ b/crates/mist-core/README.md
@@ -10,7 +10,7 @@ Add mist-core to your Cargo.toml.
 
 ```toml
 [dependencies.mist-core]
-version = "0.8"
+version = "0.9"
 ```
 
 `mist-core` provides several features: `timing`, `dialogs`, `config`, `lss`, and `bg`. These enable functionality.

--- a/crates/mist-core/src/instant.rs
+++ b/crates/mist-core/src/instant.rs
@@ -14,9 +14,9 @@ mod inner {
             denom: u32,
         }
         fn info() -> mach_timebase_info {
-            static INFO_BITS: AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            static INFO_BITS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-            let info_bits = INFO_BITS.load(std::cmp::Ordering::Relaxed);
+            let info_bits = INFO_BITS.load(std::sync::atomic::Ordering::Relaxed);
             if info_bits != 0 {
                 return info_from_bits(info_bits);
             }
@@ -29,7 +29,7 @@ mod inner {
             unsafe {
                 mach_timebase_info(&mut info);
             }
-            INFO_BITS.store(info_to_bits(info), std::cmp::Ordering::Relaxed);
+            INFO_BITS.store(info_to_bits(info), std::sync::atomic::Ordering::Relaxed);
             info
         }
 
@@ -68,7 +68,7 @@ mod inner {
                     .checked_sub(other.t)
                     .expect("overflow when subtracting instants");
                 let info = info();
-                let nanos = ((diff / info.denom) * numer) + (((diff % info.denom) * numer) / info.denom);
+                let nanos = ((diff / info.denom as u64) * info.numer as u64) + (((diff % info.denom as u64) * info.numer as u64) / info.denom as u64);
                 std::time::Duration::new(nanos / 1_000_000_000, (nanos % 1_000_000_000) as u32)
             }
         }

--- a/crates/mist-core/src/instant.rs
+++ b/crates/mist-core/src/instant.rs
@@ -3,103 +3,173 @@ pub use inner::MistInstant;
 
 #[cfg(unix)]
 mod inner {
-    #[derive(Copy, Clone)]
-    struct Timespec {
-        t: libc::timespec,
-    }
+    pub use innerinner::MistInstant;
 
-    impl PartialEq for Timespec {
-        fn eq(&self, other: &Timespec) -> bool {
-            self.t.tv_sec == other.t.tv_sec && self.t.tv_nsec == other.t.tv_nsec
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    mod innerinner {
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        struct mach_timebase_info {
+            numer: u32,
+            denom: u32,
         }
-    }
+        fn info() -> mach_timebase_info {
+            static INFO_BITS: AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-    impl Eq for Timespec {}
+            let info_bits = INFO_BITS.load(std::cmp::Ordering::Relaxed);
+            if info_bits != 0 {
+                return info_from_bits(info_bits);
+            }
 
-    impl PartialOrd for Timespec {
-        fn partial_cmp(&self, other: &Timespec) -> Option<std::cmp::Ordering> {
-            Some(self.cmp(other))
+            extern "C" {
+                fn mach_timebase_info(info: *mut mach_timebase_info) -> libc::c_int;
+            }
+
+            let mut info = info_from_bits(0);
+            unsafe {
+                mach_timebase_info(&mut info);
+            }
+            INFO_BITS.store(info_to_bits(info), std::cmp::Ordering::Relaxed);
+            info
         }
-    }
 
-    impl Ord for Timespec {
-        fn cmp(&self, other: &Timespec) -> std::cmp::Ordering {
-            let me = (self.t.tv_sec, self.t.tv_nsec);
-            let other = (other.t.tv_sec, other.t.tv_nsec);
-            me.cmp(&other)
+        #[inline]
+        fn info_to_bits(info: mach_timebase_info) -> u64 {
+            ((info.denom as u64) << 32) | (info.numer as u64)
         }
-    }
 
-    impl Timespec {
-        fn sub_timespec(&self, other: &Timespec) -> Option<std::time::Duration> {
-            if self >= other {
-                let (secs, nsec) = if self.t.tv_nsec >= other.t.tv_nsec {
-                    (
-                        (self.t.tv_sec - other.t.tv_sec) as u64,
-                        (self.t.tv_nsec - other.t.tv_nsec) as u32,
-                    )
-                } else {
-                    (
-                        (self.t.tv_sec - other.t.tv_sec - 1) as u64,
-                        self.t.tv_nsec as u32 + 1_000_000_000u32 - other.t.tv_nsec as u32,
-                    )
-                };
-                Some(std::time::Duration::new(secs, nsec))
-            } else {
-                None
+        #[inline]
+        fn info_from_bits(bits: u64) -> mach_timebase_info {
+            mach_timebase_info {
+                numer: bits as u32,
+                denom: (bits >> 32) as u32,
+            }
+        }
+        #[derive(Copy, Clone)]
+        pub struct MistInstant {
+            t: u64,
+        }
+
+        impl MistInstant {
+            pub fn now() -> Self {
+                extern "C" {
+                    fn mach_continuous_time() -> u64;
+                }
+                Self {
+                    t: unsafe { mach_continuous_time() },
+                }
+            }
+        }
+
+        impl std::ops::Sub<MistInstant> for MistInstant {
+            type Output = std::time::Duration;
+            fn sub(self, other: MistInstant) -> Self::Output {
+                let diff = self.t
+                    .checked_sub(other.t)
+                    .expect("overflow when subtracting instants");
+                let info = info();
+                let nanos = ((diff / info.denom) * numer) + (((diff % info.denom) * numer) / info.denom);
+                std::time::Duration::new(nanos / 1_000_000_000, (nanos % 1_000_000_000) as u32)
             }
         }
     }
-    #[derive(Copy, Clone)]
-    pub struct MistInstant {
-        t: Timespec,
-    }
+
     #[cfg(target_os = "linux")]
-    impl MistInstant {
-        pub fn now() -> Self {
-            Self {
-                t: now(libc::CLOCK_BOOTTIME),
+    mod innerinner {
+        #[derive(Copy, Clone)]
+        struct Timespec {
+            t: libc::timespec,
+        }
+
+        impl PartialEq for Timespec {
+            fn eq(&self, other: &Timespec) -> bool {
+                self.t.tv_sec == other.t.tv_sec && self.t.tv_nsec == other.t.tv_nsec
+            }
+        }
+
+        impl Eq for Timespec {}
+
+        impl PartialOrd for Timespec {
+            fn partial_cmp(&self, other: &Timespec) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        impl Ord for Timespec {
+            fn cmp(&self, other: &Timespec) -> std::cmp::Ordering {
+                let me = (self.t.tv_sec, self.t.tv_nsec);
+                let other = (other.t.tv_sec, other.t.tv_nsec);
+                me.cmp(&other)
+            }
+        }
+
+        impl Timespec {
+            fn sub_timespec(&self, other: &Timespec) -> Option<std::time::Duration> {
+                if self >= other {
+                    let (secs, nsec) = if self.t.tv_nsec >= other.t.tv_nsec {
+                        (
+                            (self.t.tv_sec - other.t.tv_sec) as u64,
+                            (self.t.tv_nsec - other.t.tv_nsec) as u32,
+                        )
+                    } else {
+                        (
+                            (self.t.tv_sec - other.t.tv_sec - 1) as u64,
+                            self.t.tv_nsec as u32 + 1_000_000_000u32 - other.t.tv_nsec as u32,
+                        )
+                    };
+                    Some(std::time::Duration::new(secs, nsec))
+                } else {
+                    None
+                }
+            }
+        }
+
+        #[derive(Copy, Clone)]
+        pub struct MistInstant {
+            t: Timespec,
+        }
+
+        impl MistInstant {
+            pub fn now() -> Self {
+                Self {
+                    t: now(libc::CLOCK_BOOTTIME),
+                }
+            }
+        }
+
+        #[cfg(not(any(target_os = "dragonfly", target_os = "espidf")))]
+        pub type clock_t = libc::c_int;
+        #[cfg(any(target_os = "dragonfly", target_os = "espidf"))]
+        pub type clock_t = libc::c_ulong;
+
+        fn now(clock: clock_t) -> Timespec {
+            let mut t = Timespec {
+                t: libc::timespec {
+                    tv_sec: 0,
+                    tv_nsec: 0,
+                },
+            };
+            let r = unsafe { libc::clock_gettime(clock, &mut t.t) };
+            if r == -1 {
+                panic!("couldn't clock_gettime");
+            }
+            t
+        }
+
+        impl std::ops::Sub<MistInstant> for MistInstant {
+            type Output = std::time::Duration;
+            fn sub(self, other: MistInstant) -> Self::Output {
+                self.t
+                    .sub_timespec(&other.t)
+                    .expect("overflow when subtracting instants")
             }
         }
     }
-    #[cfg(target_os = "macos")]
+
     impl MistInstant {
-        pub fn now() -> Self {
-            Self {
-                t: now(libc::CLOCK_MONOTONIC),
-            }
+        pub fn elapsed(&self) -> std::time::Duration {
+            Self::now() - *self
         }
-    }
-
-    pub type clock_t = libc::c_int;
-
-    fn now(clock: clock_t) -> Timespec {
-        let mut t = Timespec {
-            t: libc::timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            },
-        };
-        let r = unsafe { libc::clock_gettime(clock, &mut t.t) };
-        if r == -1 {
-            panic!("couldn't clock_gettime");
-        }
-        t
-    }
-
-    impl std::ops::Sub<MistInstant> for MistInstant {
-        type Output = std::time::Duration;
-        fn sub(self, other: MistInstant) -> Self::Output {
-            self.t
-                .sub_timespec(&other.t)
-                .expect("overflow when subtracting instants")
-        }
-    }
-}
-
-impl MistInstant {
-    pub fn elapsed(&self) -> std::time::Duration {
-        Self::now() - *self
     }
 }
 

--- a/crates/mist-core/src/instant.rs
+++ b/crates/mist-core/src/instant.rs
@@ -1,0 +1,92 @@
+#![allow(non_camel_case_types)]
+pub use inner::MistInstant;
+
+#[cfg(unix)]
+mod inner {
+    pub use innerinner::MistInstant;
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    mod innerinner {
+        #[derive(Copy, Clone)]
+        pub struct MistInstant {
+            t: u64
+        }
+        impl MistInstant {
+            pub fn now() -> Self {
+                extern "C" {
+                    fn mach_continuous_time() -> u64;
+                }
+                MistInstant {t: unsafe {mach_continuous_time()}}
+            }
+        }
+        impl std::ops::Sub<MistInstant> for MistInstant {
+            type Output = std::time::Duration;
+            fn sub(self, other: MistInstant) -> Self::Output {
+                self.t.checked_sub(other.t).expect("overflow when subtracting instants")
+            }
+        }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "ios", windows)))]
+    mod innerinner {
+        #[derive(Copy, Clone)]
+        struct Timespec {
+            t: libc::timespec
+        }
+        impl Timespec {
+            fn sub_timespec(&self, other: &Timespec) -> Option<std::time::Duration> {
+                if self.t.tv_sec >= other.t.tv_sec && self.t.tv_nsec >= other.t.tv_nsec {
+                    let (sec, nsec) = ((self.t.tv_sec - other.t.tv_sec) as u64, (self.t.tv_nsec - other.t.tv_nsec) as u32);
+                    Some(std::time::Duration::new(sec, nsec))
+                } else {
+                    None
+                }
+            }
+        }
+        #[derive(Copy, Clone)]
+        pub struct MistInstant {
+            t: Timespec
+        }
+        impl MistInstant {
+            pub fn now() -> Self {
+                Self {t: now(libc::CLOCK_BOOTTIME)}
+            }
+        }
+        #[cfg(not(any(target_os = "dragonfly", target_os = "espidf")))]
+        pub type clock_t = libc::c_int;
+        #[cfg(any(target_os = "dragonfly", target_os = "espidf"))]
+        pub type clock_t = libc::c_ulong;
+        fn now(clock: clock_t) -> Timespec {
+            let mut t = Timespec {t: libc::timespec {tv_sec: 0, tv_nsec: 0}};
+            let r = unsafe {libc::clock_gettime(clock, &mut t.t)};
+            if r == -1 {
+                panic!("couldn't clock_gettime");
+            }
+            t
+        }
+        impl std::ops::Sub<MistInstant> for MistInstant {
+            type Output = std::time::Duration;
+            fn sub(self, other: MistInstant) -> Self::Output {
+                self.t.sub_timespec(&other.t).expect("overflow when subtracting instants")
+            }
+        }
+    }
+    impl MistInstant {
+        pub fn elapsed(&self) -> std::time::Duration {
+            Self::now() - *self
+        }
+    }
+}
+
+
+#[cfg(windows)]
+mod inner {
+    pub struct MistInstant(std::time::Instant);
+    impl MistInstant {
+        pub fn now() -> Self {
+            MistInstant(std::time::Instant::now())
+        }
+        pub fn elapsed() -> std::time::Duration {
+            self.0.elapsed()
+        }
+    }
+}
+

--- a/crates/mist-core/src/instant.rs
+++ b/crates/mist-core/src/instant.rs
@@ -4,78 +4,134 @@ pub use inner::MistInstant;
 #[cfg(unix)]
 mod inner {
     pub use innerinner::MistInstant;
+
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     mod innerinner {
         #[derive(Copy, Clone)]
         pub struct MistInstant {
-            t: u64
+            t: u64,
         }
+
         impl MistInstant {
             pub fn now() -> Self {
                 extern "C" {
                     fn mach_continuous_time() -> u64;
                 }
-                MistInstant {t: unsafe {mach_continuous_time()}}
+                MistInstant {
+                    t: unsafe { mach_continuous_time() },
+                }
             }
         }
+
         impl std::ops::Sub<MistInstant> for MistInstant {
             type Output = std::time::Duration;
             fn sub(self, other: MistInstant) -> Self::Output {
-                self.t.checked_sub(other.t).expect("overflow when subtracting instants")
+                self.t
+                    .checked_sub(other.t)
+                    .expect("overflow when subtracting instants")
             }
         }
     }
-    #[cfg(not(any(target_os = "macos", target_os = "ios", windows)))]
+
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     mod innerinner {
         #[derive(Copy, Clone)]
         struct Timespec {
-            t: libc::timespec
+            t: libc::timespec,
         }
+
+        impl PartialEq for Timespec {
+            fn eq(&self, other: &Timespec) -> bool {
+                self.t.tv_sec == other.t.tv_sec && self.t.tv_nsec == other.t.tv_nsec
+            }
+        }
+
+        impl Eq for Timespec {}
+
+        impl PartialOrd for Timespec {
+            fn partial_cmp(&self, other: &Timespec) -> Option<std::cmp::Ordering> {
+                Some(self.cmp(other))
+            }
+        }
+
+        impl Ord for Timespec {
+            fn cmp(&self, other: &Timespec) -> std::cmp::Ordering {
+                let me = (self.t.tv_sec, self.t.tv_nsec);
+                let other = (other.t.tv_sec, other.t.tv_nsec);
+                me.cmp(&other)
+            }
+        }
+
         impl Timespec {
             fn sub_timespec(&self, other: &Timespec) -> Option<std::time::Duration> {
-                if self.t.tv_sec >= other.t.tv_sec && self.t.tv_nsec >= other.t.tv_nsec {
-                    let (sec, nsec) = ((self.t.tv_sec - other.t.tv_sec) as u64, (self.t.tv_nsec - other.t.tv_nsec) as u32);
-                    Some(std::time::Duration::new(sec, nsec))
+                if self >= other {
+                    let (secs, nsec) = if self.t.tv_nsec >= other.t.tv_nsec {
+                        (
+                            (self.t.tv_sec - other.t.tv_sec) as u64,
+                            (self.t.tv_nsec - other.t.tv_nsec) as u32,
+                        )
+                    } else {
+                        (
+                            (self.t.tv_sec - other.t.tv_sec - 1) as u64,
+                            self.t.tv_nsec as u32 + 1_000_000_000u32 - other.t.tv_nsec as u32,
+                        )
+                    };
+                    Some(std::time::Duration::new(secs, nsec))
                 } else {
                     None
                 }
             }
         }
+
+
         #[derive(Copy, Clone)]
         pub struct MistInstant {
-            t: Timespec
+            t: Timespec,
         }
+        
         impl MistInstant {
             pub fn now() -> Self {
-                Self {t: now(libc::CLOCK_BOOTTIME)}
+                Self {
+                    t: now(libc::CLOCK_BOOTTIME),
+                }
             }
         }
+
         #[cfg(not(any(target_os = "dragonfly", target_os = "espidf")))]
         pub type clock_t = libc::c_int;
         #[cfg(any(target_os = "dragonfly", target_os = "espidf"))]
         pub type clock_t = libc::c_ulong;
+
         fn now(clock: clock_t) -> Timespec {
-            let mut t = Timespec {t: libc::timespec {tv_sec: 0, tv_nsec: 0}};
-            let r = unsafe {libc::clock_gettime(clock, &mut t.t)};
+            let mut t = Timespec {
+                t: libc::timespec {
+                    tv_sec: 0,
+                    tv_nsec: 0,
+                },
+            };
+            let r = unsafe { libc::clock_gettime(clock, &mut t.t) };
             if r == -1 {
                 panic!("couldn't clock_gettime");
             }
             t
         }
+
         impl std::ops::Sub<MistInstant> for MistInstant {
             type Output = std::time::Duration;
             fn sub(self, other: MistInstant) -> Self::Output {
-                self.t.sub_timespec(&other.t).expect("overflow when subtracting instants")
+                self.t
+                    .sub_timespec(&other.t)
+                    .expect("overflow when subtracting instants")
             }
         }
     }
+
     impl MistInstant {
         pub fn elapsed(&self) -> std::time::Duration {
             Self::now() - *self
         }
     }
 }
-
 
 #[cfg(windows)]
 mod inner {
@@ -89,4 +145,3 @@ mod inner {
         }
     }
 }
-

--- a/crates/mist-core/src/instant.rs
+++ b/crates/mist-core/src/instant.rs
@@ -3,133 +3,103 @@ pub use inner::MistInstant;
 
 #[cfg(unix)]
 mod inner {
-    pub use innerinner::MistInstant;
+    #[derive(Copy, Clone)]
+    struct Timespec {
+        t: libc::timespec,
+    }
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
-    mod innerinner {
-        #[derive(Copy, Clone)]
-        pub struct MistInstant {
-            t: u64,
-        }
-
-        impl MistInstant {
-            pub fn now() -> Self {
-                extern "C" {
-                    fn mach_continuous_time() -> u64;
-                }
-                MistInstant {
-                    t: unsafe { mach_continuous_time() },
-                }
-            }
-        }
-
-        impl std::ops::Sub<MistInstant> for MistInstant {
-            type Output = std::time::Duration;
-            fn sub(self, other: MistInstant) -> Self::Output {
-                self.t
-                    .checked_sub(other.t)
-                    .expect("overflow when subtracting instants")
-            }
+    impl PartialEq for Timespec {
+        fn eq(&self, other: &Timespec) -> bool {
+            self.t.tv_sec == other.t.tv_sec && self.t.tv_nsec == other.t.tv_nsec
         }
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-    mod innerinner {
-        #[derive(Copy, Clone)]
-        struct Timespec {
-            t: libc::timespec,
+    impl Eq for Timespec {}
+
+    impl PartialOrd for Timespec {
+        fn partial_cmp(&self, other: &Timespec) -> Option<std::cmp::Ordering> {
+            Some(self.cmp(other))
         }
+    }
 
-        impl PartialEq for Timespec {
-            fn eq(&self, other: &Timespec) -> bool {
-                self.t.tv_sec == other.t.tv_sec && self.t.tv_nsec == other.t.tv_nsec
-            }
+    impl Ord for Timespec {
+        fn cmp(&self, other: &Timespec) -> std::cmp::Ordering {
+            let me = (self.t.tv_sec, self.t.tv_nsec);
+            let other = (other.t.tv_sec, other.t.tv_nsec);
+            me.cmp(&other)
         }
+    }
 
-        impl Eq for Timespec {}
-
-        impl PartialOrd for Timespec {
-            fn partial_cmp(&self, other: &Timespec) -> Option<std::cmp::Ordering> {
-                Some(self.cmp(other))
-            }
-        }
-
-        impl Ord for Timespec {
-            fn cmp(&self, other: &Timespec) -> std::cmp::Ordering {
-                let me = (self.t.tv_sec, self.t.tv_nsec);
-                let other = (other.t.tv_sec, other.t.tv_nsec);
-                me.cmp(&other)
-            }
-        }
-
-        impl Timespec {
-            fn sub_timespec(&self, other: &Timespec) -> Option<std::time::Duration> {
-                if self >= other {
-                    let (secs, nsec) = if self.t.tv_nsec >= other.t.tv_nsec {
-                        (
-                            (self.t.tv_sec - other.t.tv_sec) as u64,
-                            (self.t.tv_nsec - other.t.tv_nsec) as u32,
-                        )
-                    } else {
-                        (
-                            (self.t.tv_sec - other.t.tv_sec - 1) as u64,
-                            self.t.tv_nsec as u32 + 1_000_000_000u32 - other.t.tv_nsec as u32,
-                        )
-                    };
-                    Some(std::time::Duration::new(secs, nsec))
+    impl Timespec {
+        fn sub_timespec(&self, other: &Timespec) -> Option<std::time::Duration> {
+            if self >= other {
+                let (secs, nsec) = if self.t.tv_nsec >= other.t.tv_nsec {
+                    (
+                        (self.t.tv_sec - other.t.tv_sec) as u64,
+                        (self.t.tv_nsec - other.t.tv_nsec) as u32,
+                    )
                 } else {
-                    None
-                }
+                    (
+                        (self.t.tv_sec - other.t.tv_sec - 1) as u64,
+                        self.t.tv_nsec as u32 + 1_000_000_000u32 - other.t.tv_nsec as u32,
+                    )
+                };
+                Some(std::time::Duration::new(secs, nsec))
+            } else {
+                None
             }
         }
-
-
-        #[derive(Copy, Clone)]
-        pub struct MistInstant {
-            t: Timespec,
-        }
-        
-        impl MistInstant {
-            pub fn now() -> Self {
-                Self {
-                    t: now(libc::CLOCK_BOOTTIME),
-                }
+    }
+    #[derive(Copy, Clone)]
+    pub struct MistInstant {
+        t: Timespec,
+    }
+    #[cfg(target_os = "linux")]
+    impl MistInstant {
+        pub fn now() -> Self {
+            Self {
+                t: now(libc::CLOCK_BOOTTIME),
             }
         }
-
-        #[cfg(not(any(target_os = "dragonfly", target_os = "espidf")))]
-        pub type clock_t = libc::c_int;
-        #[cfg(any(target_os = "dragonfly", target_os = "espidf"))]
-        pub type clock_t = libc::c_ulong;
-
-        fn now(clock: clock_t) -> Timespec {
-            let mut t = Timespec {
-                t: libc::timespec {
-                    tv_sec: 0,
-                    tv_nsec: 0,
-                },
-            };
-            let r = unsafe { libc::clock_gettime(clock, &mut t.t) };
-            if r == -1 {
-                panic!("couldn't clock_gettime");
-            }
-            t
-        }
-
-        impl std::ops::Sub<MistInstant> for MistInstant {
-            type Output = std::time::Duration;
-            fn sub(self, other: MistInstant) -> Self::Output {
-                self.t
-                    .sub_timespec(&other.t)
-                    .expect("overflow when subtracting instants")
+    }
+    #[cfg(target_os = "macos")]
+    impl MistInstant {
+        pub fn now() -> Self {
+            Self {
+                t: now(libc::CLOCK_MONOTONIC),
             }
         }
     }
 
-    impl MistInstant {
-        pub fn elapsed(&self) -> std::time::Duration {
-            Self::now() - *self
+    pub type clock_t = libc::c_int;
+
+    fn now(clock: clock_t) -> Timespec {
+        let mut t = Timespec {
+            t: libc::timespec {
+                tv_sec: 0,
+                tv_nsec: 0,
+            },
+        };
+        let r = unsafe { libc::clock_gettime(clock, &mut t.t) };
+        if r == -1 {
+            panic!("couldn't clock_gettime");
         }
+        t
+    }
+
+    impl std::ops::Sub<MistInstant> for MistInstant {
+        type Output = std::time::Duration;
+        fn sub(self, other: MistInstant) -> Self::Output {
+            self.t
+                .sub_timespec(&other.t)
+                .expect("overflow when subtracting instants")
+        }
+    }
+}
+
+impl MistInstant {
+    pub fn elapsed(&self) -> std::time::Duration {
+        Self::now() - *self
     }
 }
 

--- a/crates/mist-core/src/instant.rs
+++ b/crates/mist-core/src/instant.rs
@@ -22,7 +22,7 @@ impl MistInstant {
 
 #[cfg(all(feature = "instant", unix))]
 mod inner {
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "macos"))]
     pub mod platform {
         use std::sync::atomic;
         use std::time::Duration;

--- a/crates/mist-core/src/lib.rs
+++ b/crates/mist-core/src/lib.rs
@@ -6,3 +6,9 @@ pub mod parse;
 mod run;
 pub mod timing;
 pub use run::Run;
+#[cfg(feature = "instant")]
+mod instant;
+#[cfg(feature = "instant")]
+pub use instant::MistInstant;
+#[cfg(not(feature = "instant"))]
+pub use std::time::Instant as MistInstant;

--- a/crates/mist-core/src/lib.rs
+++ b/crates/mist-core/src/lib.rs
@@ -6,9 +6,5 @@ pub mod parse;
 mod run;
 pub mod timing;
 pub use run::Run;
-#[cfg(feature = "instant")]
 mod instant;
-#[cfg(feature = "instant")]
 pub use instant::MistInstant;
-#[cfg(not(feature = "instant"))]
-pub use std::time::Instant as MistInstant;

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,6 +27,7 @@ use mist_core::{
     config::{Config, Panel},
     dialogs,
     parse::MsfParser,
+    MistInstant,
     timing, Run,
 };
 
@@ -41,7 +42,7 @@ use crate::state::TimerState;
 pub struct App {
     _context: sdl2::Sdl,
     ev_pump: sdl2::EventPump,
-    timer: Instant,
+    timer: MistInstant,
     canvas: WindowCanvas,
     ttf: sdl2::ttf::Sdl2TtfContext,
     state: TimerState,
@@ -71,7 +72,7 @@ impl App {
         let ev_pump = context.event_pump()?;
         let config = Config::open()?;
         // start the overarching application timer (kinda)
-        let timer = Instant::now();
+        let timer = MistInstant::now();
         // make an App that hasn't started and has an empty run
         let mut app = App {
             _context: context,
@@ -268,7 +269,6 @@ impl App {
                 let size = timer_font
                     .size_of(&chr.to_string())
                     .map_err(|_| get_error())?;
-                println!("{:?}", size);
                 raw.push(size.0);
                 ret.push(raw.iter().sum::<u32>());
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,8 +27,7 @@ use mist_core::{
     config::{Config, Panel},
     dialogs,
     parse::MsfParser,
-    MistInstant,
-    timing, Run,
+    timing, MistInstant, Run,
 };
 
 use crate::comparison::Comparison;


### PR DESCRIPTION
Most of this implementation is directly taken from [`time.rs`](https://github.com/rust-lang/rust/blob/master/library/std/src/sys/unix/time.rs) in the standard library. Critical differences being the use of:
* [`CLOCK_BOOTTIME`](https://man7.org/linux/man-pages/man3/clock_gettime.3.html) clockid on Linux (requires >=2.6.39)
* [`mach_continuous_time`](https://developer.apple.com/documentation/kernel/1646199-mach_continuous_time) on macOS (requires >=10.12)

The windows implementation of `std::time::Instant` uses [`QueryPerformanceCounter`](https://docs.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter) which already has the intended behavior. Therefore, on windows, `MistInstant` simply wraps an `Instant`. This wrapper is also made available by disabling the `Instant` feature flag in mist and mist-core, for use on platforms that do not support the extensions mentioned above.

resolves #7 