### PR TITLE
Add code paths to avoid subtraction overflow

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -46,7 +46,7 @@ impl<'a, 'b> App<'a, 'b> {
             .resizable()
             .build()
             .map_err(|_| get_error())?;
-
+        window.set_minimum_size(100, 100).unwrap();
         #[cfg(feature = "icon")]
         {
             let icon = Surface::from_file("assets/MIST.png")?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -46,7 +46,6 @@ impl<'a, 'b> App<'a, 'b> {
             .resizable()
             .build()
             .map_err(|_| get_error())?;
-        window.set_minimum_size(100, 100).unwrap();
         #[cfg(feature = "icon")]
         {
             let icon = Surface::from_file("assets/MIST.png")?;

--- a/src/render.rs
+++ b/src/render.rs
@@ -162,7 +162,10 @@ impl<'a, 'b> RenderState<'a, 'b> {
         };
         canvas
             .window_mut()
-            .set_minimum_size(0, timer_height + 20 + (splits_height * panels.len() as u32))
+            .set_minimum_size(
+                100,
+                timer_height + 20 + (splits_height * panels.len() as u32),
+            )
             .map_err(|_| get_error())?;
         canvas
             .window_mut()
@@ -703,7 +706,7 @@ impl<'a, 'b> RenderState<'a, 'b> {
             src.set_width(*sw);
             let wdx: i32 = if w < *dx {
                 let tmp: i32 = (*dx - w).try_into().unwrap();
-                -1 * tmp
+                -tmp
             } else {
                 (w - *dx).try_into().unwrap()
             };

--- a/src/render.rs
+++ b/src/render.rs
@@ -503,10 +503,12 @@ impl<'a, 'b> RenderState<'a, 'b> {
                 } else {
                     self.bottom_index = self.splits.len() - 1;
                 }
-            } else if self.bottom_index + diff < self.splits.len() - 1 {
+            } else if self.splits.len() > 0 && self.bottom_index + diff < self.splits.len() - 1 {
                 self.bottom_index += diff;
-            } else {
+            } else if self.splits.len() > 0 {
                 self.bottom_index = self.splits.len() - 1;
+            } else {
+                self.bottom_index = 0;
             }
         } else if y - bottom_height < all_rows_height {
             let diff = ((all_rows_height - (y - bottom_height)) / row_height) as usize + 1;
@@ -699,7 +701,13 @@ impl<'a, 'b> RenderState<'a, 'b> {
         for (idx, (sx, sw, dx, dw)) in coords.iter().enumerate() {
             src.set_x((*sx).try_into().unwrap());
             src.set_width(*sw);
-            dst.set_x((w - *dx).try_into().unwrap());
+            let wdx: i32 = if w < *dx {
+                let tmp: i32 = (*dx - w).try_into().unwrap();
+                -1 * tmp
+            } else {
+                (w - *dx).try_into().unwrap()
+            };
+            dst.set_x(wdx);
             dst.set_width(*dw);
             if idx == 3 {
                 dst.set_y((h - font_y - (self.splits_height * self.panels.len() as u32)) as i32);


### PR DESCRIPTION
Sets minimum window size, choose 100x100 

Made checks for the length of `self.splits` to avoid overflow on subtraction

If the size of the font is too wide for the window, then create an i32 that is negative from the u32 values.

😃 